### PR TITLE
Add workarounds for deprecated Spotify Audio Features API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,5 +62,18 @@ Uses Zustand with devtools middleware. Main store combines multiple slices (curr
 
 ### Known Issues
 
+- **Spotify Audio Features API Deprecated**: Spotify has deprecated their audio features endpoint that provided tempo, key, danceability, and other track analysis data. This affects most core features of the app that display track metrics and analysis.
+  - **Potential Solution**: Cyanite.ai API could be used as an alternative for audio analysis features, using ISRC codes or metadata matching to link Spotify tracks with audio analysis data.
 - Spotify access token expires after ~1 hour requiring page reload
 - Musixmatch provides only 30% of lyrics on free tier
+
+## Recent Changes & Workarounds
+
+**2025-08-13**: Applied fixes for deprecated Spotify Audio Features API:
+- **Metronome fallback**: Added 120 BPM default when tempo unavailable (`components/pages/TrackPage/TrackPage.tsx:119`)
+- **Data display fallbacks**: Added "Data unavailable" fallback for tempo, key, time signature display when API data missing
+- **Duration fix**: Changed auto-scroll and duration display to use `track.duration_ms` instead of `features.duration_ms` since track duration still available from regular Spotify API
+- **Test lyrics**: Added 5x repetition of fetched lyrics for scroll testing due to Musixmatch 30% limit
+- **Graceful degradation**: App remains functional with basic track info while audio analysis features show unavailable
+
+*Note: Update this section when making significant changes that affect app functionality or architecture*

--- a/components/pages/TrackPage/TrackPage.tsx
+++ b/components/pages/TrackPage/TrackPage.tsx
@@ -48,7 +48,15 @@ const TrackPage = ({ data }: Props) => {
       try {
         const result = (await getLyrics(track.external_ids.isrc)) as LyricsType;
         const lyrics = splitText(result.lyrics_body);
-        setFetchedLyrics(lyrics);
+        // Repeat lyrics for auto scroll testing
+        const repeatedLyrics = [
+          ...lyrics,
+          ...lyrics,
+          ...lyrics,
+          ...lyrics,
+          ...lyrics,
+        ];
+        setFetchedLyrics(repeatedLyrics);
         setIsFetching(false);
       } catch {
         setFetchedLyrics(['Lyrics not found.']);
@@ -62,26 +70,39 @@ const TrackPage = ({ data }: Props) => {
     setTempo(features.tempo);
   }, [features]);
 
+  const unavailableMsg = 'Data unavailable';
+
   const dataItems = [
     {
       title: 'Tempo',
-      value: `${formatTempo(features.tempo)} BPM`,
-      description: `Double speed -> ${features.tempo * 2}
-      Half speed -> ${features.tempo / 2}`,
+      value: features?.tempo
+        ? `${formatTempo(features.tempo)} BPM`
+        : unavailableMsg,
+      description: features?.tempo
+        ? `Double speed -> ${features.tempo * 2}
+      Half speed -> ${features.tempo / 2}`
+        : '',
     },
     {
       title: 'Key',
-      value: `${formatKey(features.key)} ${formatMode(features.mode)}`,
+      value:
+        features?.key !== undefined && features?.mode !== undefined
+          ? `${formatKey(features.key)} ${formatMode(features.mode)}`
+          : unavailableMsg,
       description: '',
     },
     {
       title: 'Time Signature',
-      value: formatTimeSignature(features.time_signature),
+      value: features?.time_signature
+        ? formatTimeSignature(features.time_signature)
+        : unavailableMsg,
       description: '',
     },
     {
       title: 'Duration',
-      value: formatDuration(features.duration_ms),
+      value: track?.duration_ms
+        ? formatDuration(track.duration_ms)
+        : unavailableMsg,
       description: '',
     },
   ];
@@ -114,11 +135,11 @@ const TrackPage = ({ data }: Props) => {
                 <DataItems items={dataItems} />
               </NewGrid>
               <NewGrid className={styles.metronome} item sm={4}>
-                <Metronome initialTempo={formatTempo(tempo)} />
+                <Metronome initialTempo={formatTempo(tempo) || 120} />
               </NewGrid>
             </NewGrid>
             <ScrollContent
-              scrollDuration={features.duration_ms}
+              scrollDuration={track.duration_ms}
               className={styles['scroll-content']}
             >
               <Lyrics lyrics={fetchedLyrics} isFetching={isFetching} />


### PR DESCRIPTION
- Add 120 BPM fallback for metronome when tempo unavailable
- Display 'Data unavailable' for missing audio features data
- Fix duration display and auto-scroll to use track.duration_ms
- Add 5x lyrics repetition for scroll testing
- Update CLAUDE.md with API deprecation info and Cyanite.ai alternative